### PR TITLE
Fixed returned value in $parm->input that must be false and not []

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -126,7 +126,7 @@ class PluginMailAnalyzer {
          if ($row = $res->next()) {
             // email already received
             // must prevent ticket creation
-            $parm->input = [];
+            $parm->input = false; //[ ];
 
             // as Ticket creation is cancelled, then email is not deleted from mailbox
             // then we need to set deletion flag to true to this email from mailbox folder
@@ -177,13 +177,14 @@ class PluginMailAnalyzer {
                   );
 
                   // prevent Ticket creation. Unfortunately it will return an error to receiver when started manually from web page
-                  $parm->input = []; // empty array...
+                  $parm->input = false; // []; // empty array...
 
                   // as Ticket creation is cancelled, then email is not deleted from mailbox
                   // then we need to set deletion flag to true to this email from mailbox folder
                   $local_mailgate->deleteMails($uid, MailCollector::ACCEPTED_FOLDER); // OK folder
 
                   return;
+
                } else {
                   // ticket creation, but linked to the closed one...
                   $parm->input['_link'] = ['link' => '1', 'tickets_id_1' => '0', 'tickets_id_2' => $row['ticket_id']];
@@ -253,7 +254,7 @@ class PluginMailAnalyzer {
       if (isset($message->threadindex)) {
          // exemple of thread-index : ac5rwreerb4gv3pcr8gdflszrsqhoa==
          // explanations to decode this property: http://msdn.microsoft.com/en-us/library/ee202481%28v=exchg.80%29.aspx
-         $messages_id[] = bin2hex(substr(imap_base64($message->threadindex), 6, 16 ));
+         $messages_id[] = bin2hex(substr(base64_decode($message->threadindex), 6, 16 ));
       }
 
       // search for 'References'

--- a/mailanalyzer.xml
+++ b/mailanalyzer.xml
@@ -25,19 +25,19 @@
    </authors>
    <versions>
       <version>
-         <num>2.0.0</num>
+         <num>2.0.1</num>
          <compatibility>9.5</compatibility>
       </version>
       <version>
-         <num>1.6.4</num>
+         <num>1.6.5</num>
          <compatibility>9.4</compatibility>
       </version>
       <version>
-         <num>1.5.1</num>
+         <num>1.5.2</num>
          <compatibility>9.3</compatibility>
       </version>
       <version>
-         <num>1.4.2</num>
+         <num>1.4.3</num>
          <compatibility>9.2</compatibility>
       </version>
       <version>

--- a/setup.php
+++ b/setup.php
@@ -1,6 +1,6 @@
 <?php
 
-define ("PLUGIN_MAILANALYZER_VERSION", "2.0.0");
+define ("PLUGIN_MAILANALYZER_VERSION", "2.0.1");
 
 /**
  * Summary of plugin_init_mailanalyzer


### PR DESCRIPTION
Fixed returned value in $parm->input that must be false and not []
Replaced imap_base64() call by base64_decode() -> imap PHP module is no longer needed
set version to 2.0.1